### PR TITLE
Implemented and AWS Lambda backed Custom Resources that forces the deletion of ECR repositories

### DIFF
--- a/text-search-capabilities/assets/func_auto_delete_ecr_images/index.py
+++ b/text-search-capabilities/assets/func_auto_delete_ecr_images/index.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# Author: Borja Pérez Guasch <bpguasch@amazon.com>
+# License: Apache 2.0
+# Summary: script that forces the deletion of a list of ECR repositories to prevent Stack deletion failure
+
+
+import boto3
+import cfnresponse
+
+
+def handler(event, context):
+    if event['RequestType'] == 'Delete':
+        # Extract event variables
+        repository_names = event['ResourceProperties']['repository_names']
+        registry_id = event['ResourceProperties']['registry_id']
+
+        client = boto3.client('ecr')
+
+        for name in repository_names:
+            client.delete_repository(
+                registryId=registry_id,
+                repositoryName=name,
+                force=True
+            )
+
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, {})


### PR DESCRIPTION
*Issue #, if available:* 1

*Description of changes:* Implemented and AWS Lambda backed Custom Resources that forces the deletion of ECR repositories to prevent Stack deletion failure


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
